### PR TITLE
Update 2022_Numerics_of_Machine_Learning.md

### DIFF
--- a/_teaching/2022_Numerics_of_Machine_Learning.md
+++ b/_teaching/2022_Numerics_of_Machine_Learning.md
@@ -17,7 +17,7 @@ img_caption:
 url_video: https://youtube.com/playlist?list=PL05umP7R6ij2lwDdj7IkuHoP9vHlEcH0s
 url_slides: https://github.com/philipphennig/NumericsOfML
 url_pdf:
-url_code: https://github.com/philipphennig/NumericsOfML
+url_code: 
 ---
 
 ## Summary


### PR DESCRIPTION
Removed the `url_code` link to the github page. As pointed out by @nathanaelbosch, there's only slides on the github page. In any case, the link was a duplicate of the slides link directly above.